### PR TITLE
Update Pest to version 4.x

### DIFF
--- a/captainhook.json
+++ b/captainhook.json
@@ -20,7 +20,7 @@
 		"enabled": true,
 		"actions": [
 			{
-				"action": "vendor/bin/pest",
+				"action": "vendor/bin/pest --no-coverage",
 				"options": [],
 				"conditions": []
 			},

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	},
 	"require-dev": {
 		"captainhook/captainhook": "^5",
-		"pestphp/pest": "^3.8",
+		"pestphp/pest": "^4.1",
 		"php-parallel-lint/php-parallel-lint": "^1.3",
 		"phpcompatibility/php-compatibility": "^9.3",
 		"phpcsstandards/php_codesniffer": "^3.13",
@@ -46,8 +46,8 @@
 		"post-autoload-dump": "vendor/bin/captainhook install -f -s",
 		"test:types": "@php ./vendor/bin/phpstan",
 		"test:style": "@php ./vendor/bin/phpcs",
-		"test:unit": "@php ./vendor/bin/pest",
-		"test:coverage": "@php -dxdebug.mode=coverage ./vendor/bin/pest --coverage",
+		"test:unit": "@php ./vendor/bin/pest --no-coverage",
+		"test:coverage": "@php -dxdebug.mode=coverage ./vendor/bin/pest",
 		"test": [
 			"@test:style",
 			"@test:types",

--- a/src/Elements/AbstractElement.php
+++ b/src/Elements/AbstractElement.php
@@ -360,14 +360,16 @@ abstract class AbstractElement implements Element
 			'parseFloatToInt' => true,
 		];
 
-		$options = $defaultOptions + $options;
+		$options = $options + $defaultOptions;
 
 		$widthUnit = preg_match('/[\d.,]*(\D*)$/', (string)$width, $matches) ? $matches[1] : 'px';
+
+		$parseFloatToInt = $options['parseFloatToInt'];
 
 		$unitParsers = [
 			'default' => 'intval',
 			'px' => 'intval',
-			'%' => $options['parseFloatToInt'] ? 'intval' : 'floatval',
+			'%' => $parseFloatToInt ? 'intval' : 'floatval',
 		];
 
 		$parser = $unitParsers[$widthUnit] ?? $unitParsers['default'];


### PR DESCRIPTION
Update pestphp/pest from 3.8.x to 4.1.x.
Update test script to use --no-coverage flag by default. Update captainhook configuration for Pest 4.x.
Fix PHPStan ternary operator issue in widthParser.