### PR TITLE
Add mjml and mj-head elements with context system

### DIFF
--- a/src/Elements/AbstractElement.php
+++ b/src/Elements/AbstractElement.php
@@ -160,6 +160,17 @@ abstract class AbstractElement implements Element
 	}
 
 	/**
+	 * Set the rendering context for this element
+	 *
+	 * @param array<string, mixed> $context
+	 * @return void
+	 */
+	public function setContext(array $context): void
+	{
+		$this->context = $context;
+	}
+
+	/**
 	 * @param string $attributeName
 	 * @return mixed|null
 	 */
@@ -315,9 +326,12 @@ abstract class AbstractElement implements Element
 
 		$output = '';
 
+		// Get the child context from this element
+		$childContext = $this->getChildContext();
+
 		foreach ($children ?? [] as $child) {
-			// Render child components.
-			$output .= ElementFactory::create($child)->render();
+			// Render child components with the parent's child context
+			$output .= ElementFactory::create($child, $childContext)->render();
 		}
 
 		return $output;

--- a/src/Elements/BodyComponents/MjColumn.php
+++ b/src/Elements/BodyComponents/MjColumn.php
@@ -214,7 +214,7 @@ class MjColumn extends AbstractElement
 			'inner-border'
 		);
 
-		$containerWidth = (float)$parentWidth / $nonRawSiblings;
+		$containerWidth = $nonRawSiblings > 0 ? (float)$parentWidth / $nonRawSiblings : (float)$parentWidth;
 		$containerWidth = $this->getAttribute('width') ?? "{$containerWidth}px";
 
 		['borders' => $borders, 'paddings' => $paddings]  = $this->getBoxWidths();
@@ -436,7 +436,7 @@ class MjColumn extends AbstractElement
 			return !$element->isRawElement();
 		}));
 
-		$percentage = 100 / $nonRawSiblings;
+		$percentage = $nonRawSiblings > 0 ? 100 / $nonRawSiblings : 100;
 
 		$width = $this->getAttribute('width') ?? "$percentage%";
 

--- a/src/Elements/Element.php
+++ b/src/Elements/Element.php
@@ -27,4 +27,12 @@ interface Element
 	public function getStyles(): array;
 
 	public function isRawElement(): bool;
+
+	/**
+	 * Set the rendering context for this element
+	 *
+	 * @param array<string, mixed> $context
+	 * @return void
+	 */
+	public function setContext(array $context): void;
 }

--- a/src/Elements/ElementFactory.php
+++ b/src/Elements/ElementFactory.php
@@ -29,9 +29,10 @@ final class ElementFactory
 	private static Node $node;
 
 	/**
+	 * @param array<string, mixed> $context
 	 * @throws Exception
 	 */
-	public static function create(Node $node): Element
+	public static function create(Node $node, array $context = []): Element
 	{
 		self::$node = $node;
 
@@ -50,6 +51,11 @@ final class ElementFactory
 					gettype($element)
 				)
 			);
+		}
+
+		// Set context on the element
+		if (!empty($context)) {
+			$element->setContext($context);
 		}
 
 		return $element;

--- a/src/Elements/HeadComponents/MjBreakpoint.php
+++ b/src/Elements/HeadComponents/MjBreakpoint.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * PHP MJML Renderer library
+ *
+ * @package MadeByDenis\PhpMjmlRenderer
+ * @link    https://github.com/dingo-d/php-mjml-renderer
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+declare(strict_types=1);
+
+namespace MadeByDenis\PhpMjmlRenderer\Elements\HeadComponents;
+
+use MadeByDenis\PhpMjmlRenderer\Elements\AbstractElement;
+
+/**
+ * Mjml Breakpoint Element
+ *
+ * @link https://documentation.mjml.io/#mj-breakpoint
+ *
+ * @since 1.0.0
+ */
+class MjBreakpoint extends AbstractElement
+{
+	public const string TAG_NAME = 'mj-breakpoint';
+
+	public const bool ENDING_TAG = false;
+
+	/**
+	 * List of allowed attributes on the element
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	protected array $allowedAttributes = [
+		'width' => [
+			'unit' => 'px',
+			'type' => 'measure',
+			'description' => 'breakpoint width',
+			'default_value' => '480px',
+		],
+	];
+
+	protected array $defaultAttributes = [
+		'width' => '480px',
+	];
+
+	public function render(): string
+	{
+		// mj-breakpoint doesn't render any HTML
+		// It's processed by mj-head to set responsive breakpoint
+		return '';
+	}
+
+	/**
+	 * @return array<string, array<string, string>>
+	 */
+	public function getStyles(): array
+	{
+		return [];
+	}
+}

--- a/src/Elements/HeadComponents/MjFont.php
+++ b/src/Elements/HeadComponents/MjFont.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * PHP MJML Renderer library
+ *
+ * @package MadeByDenis\PhpMjmlRenderer
+ * @link    https://github.com/dingo-d/php-mjml-renderer
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+declare(strict_types=1);
+
+namespace MadeByDenis\PhpMjmlRenderer\Elements\HeadComponents;
+
+use MadeByDenis\PhpMjmlRenderer\Elements\AbstractElement;
+
+/**
+ * Mjml Font Element
+ *
+ * @link https://documentation.mjml.io/#mj-font
+ *
+ * @since 1.0.0
+ */
+class MjFont extends AbstractElement
+{
+	public const string TAG_NAME = 'mj-font';
+
+	public const bool ENDING_TAG = false;
+
+	/**
+	 * List of allowed attributes on the element
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	protected array $allowedAttributes = [
+		'name' => [
+			'unit' => 'string',
+			'type' => 'string',
+			'description' => 'font name',
+			'default_value' => '',
+		],
+		'href' => [
+			'unit' => 'string',
+			'type' => 'string',
+			'description' => 'font url',
+			'default_value' => '',
+		],
+	];
+
+	protected array $defaultAttributes = [];
+
+	public function render(): string
+	{
+		$name = $this->getAttribute('name');
+		$href = $this->getAttribute('href');
+
+		if (!$href) {
+			return '';
+		}
+
+		// Render as a link tag for non-MSO clients
+		return "<!--[if !mso]><!--><link href=\"$href\" rel=\"stylesheet\" type=\"text/css\"><!--<![endif]-->";
+	}
+
+	/**
+	 * @return array<string, array<string, string>>
+	 */
+	public function getStyles(): array
+	{
+		return [];
+	}
+}

--- a/src/Elements/HeadComponents/MjHead.php
+++ b/src/Elements/HeadComponents/MjHead.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * PHP MJML Renderer library
+ *
+ * @package MadeByDenis\PhpMjmlRenderer
+ * @link    https://github.com/dingo-d/php-mjml-renderer
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+declare(strict_types=1);
+
+namespace MadeByDenis\PhpMjmlRenderer\Elements\HeadComponents;
+
+use MadeByDenis\PhpMjmlRenderer\Elements\AbstractElement;
+use MadeByDenis\PhpMjmlRenderer\Elements\ElementFactory;
+
+/**
+ * Mjml Head Element
+ *
+ * @link https://documentation.mjml.io/#mj-head
+ *
+ * @since 1.0.0
+ */
+class MjHead extends AbstractElement
+{
+	public const string TAG_NAME = 'mj-head';
+
+	public const bool ENDING_TAG = false;
+
+	/**
+	 * List of allowed attributes on the element
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	protected array $allowedAttributes = [];
+
+	protected array $defaultAttributes = [];
+
+	public function render(): string
+	{
+		$children = $this->getChildren() ?? [];
+
+		$title = '';
+		$preview = '';
+		$styles = '';
+		$fonts = [];
+		$breakpoint = '480px';
+
+		// Process head components
+		foreach ($children as $child) {
+			$tag = $child->getTag();
+			$element = ElementFactory::create($child);
+
+			match ($tag) {
+				'mj-title' => $title = $element->render(),
+				'mj-preview' => $preview = $element->render(),
+				'mj-style' => $styles .= $element->render(),
+				'mj-font' => $fonts[] = $element->render(),
+				'mj-breakpoint' => $breakpoint = $child->getAttributeValue('width') ?: '480px',
+				default => null,
+			};
+		}
+
+		// Build head content
+		$head = '<head>';
+		$head .= $title ?: '<title></title>';
+		$head .= '<!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->';
+		$head .= '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">';
+		$head .= '<meta name="viewport" content="width=device-width,initial-scale=1">';
+		$head .= $this->renderBaseStyles();
+		$head .= $this->renderMsoStyles();
+		$head .= $this->renderOutlookStyles();
+
+		// Add fonts
+		foreach ($fonts as $font) {
+			$head .= $font;
+		}
+
+		// Add responsive styles
+		$head .= $this->renderResponsiveStyles($breakpoint);
+
+		// Add custom styles
+		$head .= $styles;
+
+		// Add preview
+		$head .= $preview;
+
+		$head .= '</head>';
+
+		return $head;
+	}
+
+	private function renderBaseStyles(): string
+	{
+		$styles = '<style type="text/css">#outlook a { padding:0; }' . "\n";
+		$styles .= '          body { margin:0;padding:0;';
+		$styles .= '-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }' . "\n";
+		$styles .= '          table, td { border-collapse:collapse;';
+		$styles .= 'mso-table-lspace:0pt;mso-table-rspace:0pt; }' . "\n";
+		$styles .= '          img { border:0;height:auto;line-height:100%; outline:none;';
+		$styles .= 'text-decoration:none;-ms-interpolation-mode:bicubic; }' . "\n";
+		$styles .= '          p { display:block;margin:13px 0; }</style>';
+
+		return $styles;
+	}
+
+	private function renderMsoStyles(): string
+	{
+		$msoStyles = '<!--[if mso]>';
+		$msoStyles .= '<noscript><xml><o:OfficeDocumentSettings>';
+		$msoStyles .= '<o:AllowPNG/><o:PixelsPerInch>96</o:PixelsPerInch>';
+		$msoStyles .= '</o:OfficeDocumentSettings></xml></noscript>';
+		$msoStyles .= '<![endif]-->';
+
+		return $msoStyles;
+	}
+
+	private function renderOutlookStyles(): string
+	{
+		return '<!--[if lte mso 11]>
+        <style type="text/css">
+          .mj-outlook-group-fix { width:100% !important; }
+        </style>
+        <![endif]-->';
+	}
+
+	private function renderResponsiveStyles(string $breakpoint): string
+	{
+		$minWidth = $breakpoint;
+
+		$styles = '<!--[if !mso]><!-->';
+		$styles .= '<link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" ';
+		$styles .= 'rel="stylesheet" type="text/css">';
+		$styles .= '<style type="text/css">';
+		$styles .= '@import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);';
+		$styles .= '</style><!--<![endif]-->';
+		$styles .= "<style type=\"text/css\">@media only screen and (min-width:$minWidth) {";
+		$styles .= ' .mj-column-per-100 { width:100% !important; max-width: 100%; }';
+		$styles .= ' }</style>';
+		$styles .= "<style media=\"screen and (min-width:$minWidth)\">";
+		$styles .= '.moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }';
+		$styles .= '</style><style type="text/css"></style>';
+
+		return $styles;
+	}
+
+	/**
+	 * @return array<string, array<string, string>>
+	 */
+	public function getStyles(): array
+	{
+		return [];
+	}
+}

--- a/src/Elements/HeadComponents/MjPreview.php
+++ b/src/Elements/HeadComponents/MjPreview.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * PHP MJML Renderer library
+ *
+ * @package MadeByDenis\PhpMjmlRenderer
+ * @link    https://github.com/dingo-d/php-mjml-renderer
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+declare(strict_types=1);
+
+namespace MadeByDenis\PhpMjmlRenderer\Elements\HeadComponents;
+
+use MadeByDenis\PhpMjmlRenderer\Elements\AbstractElement;
+
+/**
+ * Mjml Preview Element
+ *
+ * @link https://documentation.mjml.io/#mj-preview
+ *
+ * @since 1.0.0
+ */
+class MjPreview extends AbstractElement
+{
+	public const string TAG_NAME = 'mj-preview';
+
+	public const bool ENDING_TAG = true;
+
+	/**
+	 * List of allowed attributes on the element
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	protected array $allowedAttributes = [];
+
+	protected array $defaultAttributes = [];
+
+	public function render(): string
+	{
+		$content = $this->getContent();
+
+		// Preview text is hidden but available for email clients
+		$previewStyle = 'display:none;font-size:1px;color:#ffffff;line-height:1px;';
+		$previewStyle .= 'max-height:0px;max-width:0px;opacity:0;overflow:hidden;';
+
+		return "<div style=\"$previewStyle\">$content</div>";
+	}
+
+	/**
+	 * @return array<string, array<string, string>>
+	 */
+	public function getStyles(): array
+	{
+		return [];
+	}
+}

--- a/src/Elements/HeadComponents/MjStyle.php
+++ b/src/Elements/HeadComponents/MjStyle.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * PHP MJML Renderer library
+ *
+ * @package MadeByDenis\PhpMjmlRenderer
+ * @link    https://github.com/dingo-d/php-mjml-renderer
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+declare(strict_types=1);
+
+namespace MadeByDenis\PhpMjmlRenderer\Elements\HeadComponents;
+
+use MadeByDenis\PhpMjmlRenderer\Elements\AbstractElement;
+
+/**
+ * Mjml Style Element
+ *
+ * @link https://documentation.mjml.io/#mj-style
+ *
+ * @since 1.0.0
+ */
+class MjStyle extends AbstractElement
+{
+	public const string TAG_NAME = 'mj-style';
+
+	public const bool ENDING_TAG = true;
+
+	/**
+	 * List of allowed attributes on the element
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	protected array $allowedAttributes = [
+		'inline' => [
+			'unit' => 'string',
+			'type' => 'string',
+			'description' => 'whether styles should be inlined',
+			'default_value' => '',
+		],
+	];
+
+	protected array $defaultAttributes = [];
+
+	public function render(): string
+	{
+		$content = $this->getContent();
+		$inline = $this->getAttribute('inline');
+
+		// For now, we'll always render as a style tag in head
+		// Inline styles would require processing during body rendering
+		return "<style type=\"text/css\">$content</style>";
+	}
+
+	/**
+	 * @return array<string, array<string, string>>
+	 */
+	public function getStyles(): array
+	{
+		return [];
+	}
+}

--- a/src/Elements/HeadComponents/MjTitle.php
+++ b/src/Elements/HeadComponents/MjTitle.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * PHP MJML Renderer library
+ *
+ * @package MadeByDenis\PhpMjmlRenderer
+ * @link    https://github.com/dingo-d/php-mjml-renderer
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+declare(strict_types=1);
+
+namespace MadeByDenis\PhpMjmlRenderer\Elements\HeadComponents;
+
+use MadeByDenis\PhpMjmlRenderer\Elements\AbstractElement;
+
+/**
+ * Mjml Title Element
+ *
+ * @link https://documentation.mjml.io/#mj-title
+ *
+ * @since 1.0.0
+ */
+class MjTitle extends AbstractElement
+{
+	public const string TAG_NAME = 'mj-title';
+
+	public const bool ENDING_TAG = true;
+
+	/**
+	 * List of allowed attributes on the element
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	protected array $allowedAttributes = [];
+
+	protected array $defaultAttributes = [];
+
+	public function render(): string
+	{
+		$content = $this->getContent();
+
+		return "<title>$content</title>";
+	}
+
+	/**
+	 * @return array<string, array<string, string>>
+	 */
+	public function getStyles(): array
+	{
+		return [];
+	}
+}

--- a/src/Elements/Mjml.php
+++ b/src/Elements/Mjml.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * PHP MJML Renderer library
+ *
+ * @package MadeByDenis\PhpMjmlRenderer
+ * @link    https://github.com/dingo-d/php-mjml-renderer
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+declare(strict_types=1);
+
+namespace MadeByDenis\PhpMjmlRenderer\Elements;
+
+/**
+ * Mjml Root Element
+ *
+ * @link https://documentation.mjml.io/#mjml
+ *
+ * @since 1.0.0
+ */
+class Mjml extends AbstractElement
+{
+	public const string TAG_NAME = 'mjml';
+
+	public const bool ENDING_TAG = false;
+
+	/**
+	 * List of allowed attributes on the element
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	protected array $allowedAttributes = [
+		'owa' => [
+			'unit' => 'string',
+			'type' => 'string',
+			'description' => 'option to force desktop version for older Outlook.com',
+			'default_value' => 'desktop',
+		],
+		'lang' => [
+			'unit' => 'string',
+			'type' => 'string',
+			'description' => 'html lang attribute',
+			'default_value' => 'und',
+		],
+		'dir' => [
+			'unit' => 'string',
+			'type' => 'string',
+			'description' => 'html text direction',
+			'default_value' => 'auto',
+		],
+	];
+
+	protected array $defaultAttributes = [
+		'owa' => 'desktop',
+		'lang' => 'und',
+		'dir' => 'auto',
+	];
+
+	public function render(): string
+	{
+		$children = $this->getChildren() ?? [];
+
+		// Initialize default context
+		$initialContext = [
+			'containerWidth' => '600px',
+		];
+
+		// Render head and body separately
+		$head = '';
+		$body = '';
+		$hasHead = false;
+
+		foreach ($children as $child) {
+			$tag = $child->getTag();
+
+			if ($tag === 'mj-head') {
+				$element = ElementFactory::create($child);
+				$head = $element->render();
+				$hasHead = true;
+			} elseif ($tag === 'mj-body') {
+				$element = ElementFactory::create($child, $initialContext);
+				$body = $element->render();
+			}
+		}
+
+		// If no mj-head is present, generate a default one
+		if (!$hasHead) {
+			$defaultHead = new HeadComponents\MjHead();
+			$head = $defaultHead->render();
+		}
+
+		$lang = $this->getAttribute('lang');
+		$dir = $this->getAttribute('dir');
+
+		return $this->renderDoctype() .
+			$this->renderHtmlStart($lang, $dir) .
+			$head .
+			$this->renderBodyStart() .
+			$body .
+			$this->renderBodyEnd() .
+			$this->renderHtmlEnd();
+	}
+
+	private function renderDoctype(): string
+	{
+		return '<!doctype html>';
+	}
+
+	private function renderHtmlStart(string $lang, string $dir): string
+	{
+		$html = '<html xmlns="http://www.w3.org/1999/xhtml" ';
+		$html .= 'xmlns:v="urn:schemas-microsoft-com:vml" ';
+		$html .= 'xmlns:o="urn:schemas-microsoft-com:office:office">';
+
+		return $html;
+	}
+
+	private function renderBodyStart(): string
+	{
+		return '<body style="word-spacing:normal;">';
+	}
+
+	private function renderBodyEnd(): string
+	{
+		return '</body>';
+	}
+
+	private function renderHtmlEnd(): string
+	{
+		return '</html>';
+	}
+
+	/**
+	 * @return array<string, array<string, string>>
+	 */
+	public function getStyles(): array
+	{
+		return [];
+	}
+}

--- a/src/Renderer/MjmlRenderer.php
+++ b/src/Renderer/MjmlRenderer.php
@@ -37,24 +37,8 @@ class MjmlRenderer implements Renderer
 
 		$parsedContent = $parser->parse($content);
 
-		$contentRender = function (Node $nodeElement, string $content) use (&$contentRender) {
-			if (!$nodeElement->hasChildren()) {
-				$content .= ElementFactory::create($nodeElement)->render();
-
-				return $content;
-			}
-
-			foreach ($nodeElement->getChildren() as $childNode) {
-				if ($childNode->hasChildren()) {
-					$contentRender($childNode, $content);
-				} else {
-					$content .= ElementFactory::create($childNode)->render();
-				}
-			}
-
-			return $content;
-		};
-
-		return $contentRender($parsedContent, '');
+		// Create the root element and render it.
+		// Each element handles rendering its own children via renderChildren().
+		return ElementFactory::create($parsedContent)->render();
 	}
 }

--- a/tests/Unit/Renderer/RenderTest.php
+++ b/tests/Unit/Renderer/RenderTest.php
@@ -47,7 +47,7 @@ HTML;
 	$htmlOut = $this->renderer->render($mjml);
 
 	expect($htmlOut)->toEqual($htmlExpected);
-})->skip();
+})->skip('MjSection rendering needs refactoring to match MJML spec');
 
 it('renders the MJML to correct HTML version with attributes', function () {
 	$mjml = <<<'MJML'


### PR DESCRIPTION
- Create Mjml root element that renders complete HTML document
- Create MjHead element with default styles and responsive support
- Add mj-head child components:
  * MjTitle: Document title element
  * MjPreview: Email preview text element
  * MjStyle: Custom CSS styles element
  * MjFont: Custom font import element
  * MjBreakpoint: Responsive breakpoint configuration
- Implement context passing system for element hierarchy:
  * Add setContext() method to Element interface and AbstractElement
  * Update ElementFactory::create() to accept and set context
  * Modify renderChildren() to pass parent context to children
- Fix MjmlRenderer to use simpler element creation approach
- Initialize default containerWidth context in Mjml element
- Skip renderer integration test pending MjSection refactoring

All tests pass. PHPStan analysis passes with 0 errors.