### PR TITLE
Implement mj-divider element

### DIFF
--- a/src/Elements/BodyComponents/MjDivider.php
+++ b/src/Elements/BodyComponents/MjDivider.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * PHP MJML Renderer library
+ *
+ * @package MadeByDenis\PhpMjmlRenderer
+ * @link    https://github.com/dingo-d/php-mjml-renderer
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+declare(strict_types=1);
+
+namespace MadeByDenis\PhpMjmlRenderer\Elements\BodyComponents;
+
+use MadeByDenis\PhpMjmlRenderer\Elements\AbstractElement;
+
+/**
+ * Mjml Divider Element
+ *
+ * @link https://documentation.mjml.io/#mj-divider
+ *
+ * @since 1.0.0
+ */
+class MjDivider extends AbstractElement
+{
+	public const string TAG_NAME = 'mj-divider';
+
+	public const bool ENDING_TAG = false;
+
+	/**
+	 * List of allowed attributes on the element
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	protected array $allowedAttributes = [
+		'border-color' => [
+			'unit' => 'color',
+			'type' => 'color',
+			'description' => 'divider color',
+			'default_value' => '#000000',
+		],
+		'border-style' => [
+			'unit' => 'string',
+			'type' => 'string',
+			'description' => 'dashed/dotted/solid',
+			'default_value' => 'solid',
+		],
+		'border-width' => [
+			'unit' => 'px',
+			'type' => 'measure',
+			'description' => 'divider width',
+			'default_value' => '4px',
+		],
+		'container-background-color' => [
+			'unit' => 'color',
+			'type' => 'color',
+			'description' => 'inner element background color',
+			'default_value' => '',
+		],
+		'css-class' => [
+			'unit' => 'string',
+			'type' => 'string',
+			'description' => 'class name added to root HTML element',
+			'default_value' => '',
+		],
+		'padding' => [
+			'unit' => 'px',
+			'type' => 'measure',
+			'description' => 'supports up to 4 parameters',
+			'default_value' => '10px 25px',
+		],
+		'padding-top' => [
+			'unit' => 'px',
+			'type' => 'measure',
+			'description' => 'top offset',
+			'default_value' => '',
+		],
+		'padding-bottom' => [
+			'unit' => 'px',
+			'type' => 'measure',
+			'description' => 'bottom offset',
+			'default_value' => '',
+		],
+		'padding-left' => [
+			'unit' => 'px',
+			'type' => 'measure',
+			'description' => 'left offset',
+			'default_value' => '',
+		],
+		'padding-right' => [
+			'unit' => 'px',
+			'type' => 'measure',
+			'description' => 'right offset',
+			'default_value' => '',
+		],
+		'width' => [
+			'unit' => 'px,%',
+			'type' => 'measure',
+			'description' => 'divider width',
+			'default_value' => '100%',
+		],
+	];
+
+	protected array $defaultAttributes = [
+		'border-color' => '#000000',
+		'border-style' => 'solid',
+		'border-width' => '4px',
+		'padding' => '10px 25px',
+		'width' => '100%',
+	];
+
+	public function render(): string
+	{
+		$pAttributes = $this->getHtmlAttributes([
+			'style' => 'p',
+		]);
+
+		return "<p $pAttributes></p>";
+	}
+
+	/**
+	 * @return array<string, array<string, string>>
+	 */
+	public function getStyles(): array
+	{
+		return [
+			'p' => [
+				'border-top' => $this->getAttribute('border-width') . ' ' .
+					$this->getAttribute('border-style') . ' ' .
+					$this->getAttribute('border-color'),
+				'font-size' => '1px',
+				'margin' => '0px auto',
+				'width' => $this->getAttribute('width'),
+			],
+		];
+	}
+}

--- a/tests/Unit/Elements/BodyComponents/MjDividerTest.php
+++ b/tests/Unit/Elements/BodyComponents/MjDividerTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace MadeByDenis\PhpMjmlRenderer\Tests\Unit\Elements\BodyComponents;
+
+use MadeByDenis\PhpMjmlRenderer\Elements\BodyComponents\MjDivider;
+use MadeByDenis\PhpMjmlRenderer\Elements\ElementFactory;
+use MadeByDenis\PhpMjmlRenderer\Parser\MjmlNode;
+use OutOfBoundsException;
+
+beforeEach(function () {
+	$this->element = new MjDivider();
+});
+
+it('is not ending tag', function () {
+	expect($this->element->isEndingTag())->toBe(false);
+});
+
+it('returns the correct component name', function () {
+	expect($this->element->getTagName())->toBe('mj-divider');
+});
+
+it('returns the correct default attributes', function () {
+	$attributes = [
+		'border-color' => '#000000',
+		'border-style' => 'solid',
+		'border-width' => '4px',
+		'padding' => '10px 25px',
+		'width' => '100%',
+	];
+
+	foreach ($attributes as $key => $value) {
+		expect($this->element->getAttribute($key))->toBe($value);
+	}
+});
+
+it('will throw out of bounds exception if the allowed attribute is not existing', function () {
+	$this->element->getAllowedAttributeData('invalid-attribute');
+})->throws(OutOfBoundsException::class);
+
+it('will return allowed attribute data', function () {
+	$data = $this->element->getAllowedAttributeData('border-color');
+	expect($data)->toBeArray();
+	expect($data)->toHaveKey('type');
+	expect($data)->toHaveKey('unit');
+});
+
+it('will correctly render a simple divider', function () {
+	$dividerNode = new MjmlNode(
+		'mj-divider',
+		null,
+		null,
+		false,
+		null
+	);
+
+	$factory = new ElementFactory();
+	$mjDividerElement = $factory->create($dividerNode);
+
+	expect($mjDividerElement)->toBeInstanceOf(MjDivider::class);
+
+	$out = $mjDividerElement->render();
+
+	expect($out)->toContain('<p');
+	expect($out)->toContain('border-top');
+	expect($out)->not->toBeEmpty();
+});
+
+it('will correctly render a divider with custom color', function () {
+	$dividerNode = new MjmlNode(
+		'mj-divider',
+		['border-color' => '#ff0000'],
+		null,
+		false,
+		null
+	);
+
+	$factory = new ElementFactory();
+	$mjDividerElement = $factory->create($dividerNode);
+
+	$out = $mjDividerElement->render();
+
+	expect($out)->toContain('#ff0000');
+	expect($out)->not->toBeEmpty();
+});
+
+it('will correctly render a divider with custom width', function () {
+	$dividerNode = new MjmlNode(
+		'mj-divider',
+		['border-width' => '2px'],
+		null,
+		false,
+		null
+	);
+
+	$factory = new ElementFactory();
+	$mjDividerElement = $factory->create($dividerNode);
+
+	$out = $mjDividerElement->render();
+
+	expect($out)->toContain('2px');
+	expect($out)->not->toBeEmpty();
+});
+
+it('will correctly render a divider with dashed style', function () {
+	$dividerNode = new MjmlNode(
+		'mj-divider',
+		['border-style' => 'dashed'],
+		null,
+		false,
+		null
+	);
+
+	$factory = new ElementFactory();
+	$mjDividerElement = $factory->create($dividerNode);
+
+	$out = $mjDividerElement->render();
+
+	expect($out)->toContain('dashed');
+	expect($out)->not->toBeEmpty();
+});
+
+it('will correctly render a divider with dotted style', function () {
+	$dividerNode = new MjmlNode(
+		'mj-divider',
+		['border-style' => 'dotted'],
+		null,
+		false,
+		null
+	);
+
+	$factory = new ElementFactory();
+	$mjDividerElement = $factory->create($dividerNode);
+
+	$out = $mjDividerElement->render();
+
+	expect($out)->toContain('dotted');
+	expect($out)->not->toBeEmpty();
+});
+
+it('will correctly render a divider with custom width percentage', function () {
+	$dividerNode = new MjmlNode(
+		'mj-divider',
+		['width' => '50%'],
+		null,
+		false,
+		null
+	);
+
+	$factory = new ElementFactory();
+	$mjDividerElement = $factory->create($dividerNode);
+
+	$out = $mjDividerElement->render();
+
+	expect($out)->toContain('width');
+	expect($out)->toContain('50%');
+	expect($out)->not->toBeEmpty();
+});
+
+it('will correctly render a divider with all custom properties', function () {
+	$dividerNode = new MjmlNode(
+		'mj-divider',
+		[
+			'border-color' => '#cccccc',
+			'border-style' => 'dashed',
+			'border-width' => '1px',
+			'width' => '80%',
+		],
+		null,
+		false,
+		null
+	);
+
+	$factory = new ElementFactory();
+	$mjDividerElement = $factory->create($dividerNode);
+
+	$out = $mjDividerElement->render();
+
+	expect($out)->toContain('#cccccc');
+	expect($out)->toContain('dashed');
+	expect($out)->toContain('1px');
+	expect($out)->toContain('80%');
+	expect($out)->not->toBeEmpty();
+});


### PR DESCRIPTION
Add horizontal divider support with customizable styling.

- Create MjDivider class with 11 configurable attributes
- Support border color, width, and style (solid/dashed/dotted)
- Handle width as percentage or pixel values
- Generate paragraph-based divider for email compatibility
- Add comprehensive test coverage with 12 test cases